### PR TITLE
Yassine/bump wrapt

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ DESCRIPTION = 'This package is intended to provide a uniform schema for common m
 DEPENDENCIES = [
     'python_dateutil>=2.5.3',
     'pytz>=2017.2',
-    'wrapt==1.11.1'
+    'wrapt>=1.12.1'
 ]
 
 EXTRAS = {

--- a/tests/test_requirements.txt
+++ b/tests/test_requirements.txt
@@ -1,6 +1,6 @@
 python_dateutil>=2.5.3
 pytz>=2017.2
-wrapt==1.11.1
+wrapt>=1.12.1
 numpy>=1.13.0
 pandas>=0.20.2
 pyspark==2.3.2


### PR DESCRIPTION
This PR loosen the range of wrapt as it causes conflict for customers that deploy endpoint with tensorflow 2.4.1

===========
The conflict is caused by:
inference-schema 1.2.0 depends on wrapt==1.11.1
tensorflow 2.4.1 depends on wrapt~=1.12.1


