### PR TITLE
Fix issue with pandas column label types

### DIFF
--- a/inference_schema/parameter_types/pandas_parameter_type.py
+++ b/inference_schema/parameter_types/pandas_parameter_type.py
@@ -68,7 +68,7 @@ class PandasParameterType(AbstractParameterType):
         data_frame = pd.read_json(json.dumps(input_data), orient=self.orient)
 
         if self.apply_column_names and isinstance(input_data, list) and not isinstance(input_data[0], dict):
-            data_frame.columns = self.sample_input.columns
+            data_frame.columns = self.sample_input.columns.copy()
 
         if self.enforce_column_type:
             sample_input_column_types = self.sample_input.dtypes.to_dict()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,6 +58,12 @@ def pandas_sample_output():
 
 
 @pytest.fixture(scope="session")
+def pandas_sample_input_multi_type_column_labels():
+    pandas_input_data = {'name': ['Sarah', 'John'], 1: ['WA', 'CA']}
+    return pd.DataFrame(data=pandas_input_data)
+
+
+@pytest.fixture(scope="session")
 def decorated_pandas_func(pandas_sample_input, pandas_sample_output):
     @input_schema('param', PandasParameterType(pandas_sample_input))
     @output_schema(PandasParameterType(pandas_sample_output))
@@ -109,6 +115,25 @@ def decorated_pandas_func_split_orient(pandas_sample_input, pandas_sample_output
         """
         assert type(param) is pd.DataFrame
         return pd.DataFrame(param['state'])
+
+    return pandas_split_orient_func
+
+
+@pytest.fixture(scope="session")
+def decorated_pandas_func_multi_type_column_labels(pandas_sample_input_multi_type_column_labels):
+
+    @input_schema('param', PandasParameterType(pandas_sample_input_multi_type_column_labels))
+    def pandas_split_orient_func(param):
+        """
+
+        :param param:
+        :type param: pd.DataFrame
+        :return:
+        :rtype: pd.DataFrame
+        """
+        assert param["name"] is not None
+        assert param[1] is not None
+        return param
 
     return pandas_split_orient_func
 

--- a/tests/test_pandas_parameter_type.py
+++ b/tests/test_pandas_parameter_type.py
@@ -39,6 +39,11 @@ class TestPandasParameterType(object):
         result = decorated_pandas_datetime_func(**pandas_input)
         assert_frame_equal(result, datetime)
 
+    def test_pandas_multi_type_columns_labels_handling(self, decorated_pandas_func_multi_type_column_labels,
+                                                       pandas_sample_input_multi_type_column_labels):
+        result = decorated_pandas_func_multi_type_column_labels(pandas_sample_input_multi_type_column_labels)
+        assert_frame_equal(result, pandas_sample_input_multi_type_column_labels)
+
 
 class TestNestedType(object):
 


### PR DESCRIPTION
Using `copy` will maintain column label types. This would be seen as an issue primarily with dataframes that expect integer column labels.