### PR TITLE
Fix Pandas datetime handling

### DIFF
--- a/inference_schema/parameter_types/pandas_parameter_type.py
+++ b/inference_schema/parameter_types/pandas_parameter_type.py
@@ -109,35 +109,36 @@ class PandasParameterType(AbstractParameterType):
             swagger_schema = get_swagger_for_nested_dict(json_sample)
 
         if self.orient == 'records':
-            for column_name, column_info in swagger_schema['items']['properties'].items():
+            for column_name in self.sample_input.columns:
                 data_type = str(self.sample_input.dtypes[column_name])
                 if data_type.startswith('datetime'):
-                    column_info['format'] = 'date-time'
+                    swagger_schema['items']['properties'][str(column_name)]['format'] = 'date-time'
                 elif data_type.startswith('timedelta'):
-                    column_info['format'] = 'timedelta'
+                    swagger_schema['items']['properties'][str(column_name)]['format'] = 'timedelta'
         elif self.orient == 'index':
             for row in swagger_schema['properties'].values():
-                for column_name, column_info in row['properties'].items():
+                for column_name in self.sample_input.columns:
                     data_type = str(self.sample_input.dtypes[column_name])
                     if data_type.startswith('datetime'):
-                        column_info['format'] = 'date-time'
+                        row['properties'][str(column_name)]['format'] = 'date-time'
                     elif data_type.startswith('timedelta'):
-                        column_info['format'] = 'timedelta'
+                        row['properties'][str(column_name)]['format'] = 'timedelta'
         elif self.orient == 'columns':
-            for column_name, column_info in swagger_schema['properties'].items():
-                for row_info in column_info['properties'].values():
+            for column_name in self.sample_input.columns:
+                for row_info in swagger_schema['properties'][str(column_name)]['properties'].values():
                     data_type = str(self.sample_input.dtypes[column_name])
                     if data_type.startswith('datetime'):
                         row_info['format'] = 'date-time'
                     elif data_type.startswith('timedelta'):
                         row_info['format'] = 'timedelta'
         elif self.orient == 'table':
-            for column_name, column_info in swagger_schema['properties']['data']['items']['properties'].items():
-                if column_name != 'index':
-                    data_type = str(self.sample_input.dtypes[column_name])
-                    if data_type.startswith('datetime'):
-                        column_info['format'] = 'date-time'
-                    elif data_type.startswith('timedelta'):
-                        column_info['format'] = 'timedelta'
+            for column_name in self.sample_input.columns:
+                data_type = str(self.sample_input.dtypes[column_name])
+                if data_type.startswith('datetime'):
+                    swagger_schema['properties']['data']['items']['properties'][str(column_name)]['format'] = \
+                        'date-time'
+                elif data_type.startswith('timedelta'):
+                    swagger_schema['properties']['data']['items']['properties'][str(column_name)]['format'] = \
+                        'timedelta'
 
         return swagger_schema

--- a/inference_schema/parameter_types/pandas_parameter_type.py
+++ b/inference_schema/parameter_types/pandas_parameter_type.py
@@ -73,6 +73,9 @@ class PandasParameterType(AbstractParameterType):
         if self.enforce_column_type:
             sample_input_column_types = self.sample_input.dtypes.to_dict()
             converted_types = {x: sample_input_column_types.get(x, object) for x in data_frame.columns}
+            for column_name, column_type in converted_types.items():
+                if str(column_type).startswith('timedelta'):
+                    data_frame[column_name] = pd.to_timedelta(data_frame[column_name])
             data_frame = data_frame.astype(dtype=converted_types)
 
         if self.enforce_shape:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -84,7 +84,8 @@ def decorated_pandas_func(pandas_sample_input, pandas_sample_output):
 @pytest.fixture(scope="session")
 def decorated_pandas_datetime_func():
     pandas_sample_timestamp_input = pd.DataFrame({'datetime': pd.Series(['2013-12-31T00:00:00.000Z'],
-                                                                        dtype='datetime64[ns]')})
+                                                                        dtype='datetime64[ns]'),
+                                                  'days': pd.Series([pd.Timedelta(days=1)])})
 
     @input_schema('param', PandasParameterType(pandas_sample_timestamp_input))
     def pandas_datetime_func(param):

--- a/tests/resources/sample_pandas_datetime_schema.json
+++ b/tests/resources/sample_pandas_datetime_schema.json
@@ -1,0 +1,17 @@
+{
+    "type": "array",
+    "items": {
+        "type": "object",
+        "required": ["datetime"],
+        "properties": {
+            "datetime": {
+                "type": "string",
+                "format": "date-time"
+            }
+        }
+    },
+    "example": [{
+            "datetime": "2013-12-31T00:00:00.000Z"
+        }
+    ]
+}

--- a/tests/resources/sample_pandas_datetime_schema.json
+++ b/tests/resources/sample_pandas_datetime_schema.json
@@ -1,17 +1,27 @@
 {
-    "type": "array",
-    "items": {
-        "type": "object",
-        "required": ["datetime"],
-        "properties": {
-            "datetime": {
-                "type": "string",
-                "format": "date-time"
+    "type": "object",
+	"properties": {
+		"param": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": [
+                    "datetime"
+                ],
+                "properties": {
+                    "datetime": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                }
             }
         }
     },
-    "example": [{
-            "datetime": "2013-12-31T00:00:00.000Z"
-        }
-    ]
+    "example": {
+        "param": [
+            {
+                "datetime": "2013-12-31T00:00:00.000Z"
+            }
+        ]
+    }
 }

--- a/tests/resources/sample_pandas_datetime_schema.json
+++ b/tests/resources/sample_pandas_datetime_schema.json
@@ -6,12 +6,17 @@
             "items": {
                 "type": "object",
                 "required": [
-                    "datetime"
+                    "datetime",
+                    "days"
                 ],
                 "properties": {
                     "datetime": {
                         "type": "string",
                         "format": "date-time"
+                    },
+                    "days": {
+                        "type": "string",
+                        "format": "timedelta"
                     }
                 }
             }
@@ -20,7 +25,8 @@
     "example": {
         "param": [
             {
-                "datetime": "2013-12-31T00:00:00.000Z"
+                "datetime": "2013-12-31T00:00:00.000Z",
+                "days": "P1DT0H0M0S"
             }
         ]
     }

--- a/tests/test_pandas_parameter_type.py
+++ b/tests/test_pandas_parameter_type.py
@@ -33,7 +33,8 @@ class TestPandasParameterType(object):
 
     def test_pandas_timestamp_handling(self, decorated_pandas_datetime_func):
         datetime_str = '2013-12-31 00:00:00,000000'
-        pandas_input = {'param': [{'datetime': datetime_str}]}
+        timedelta_str = 'P1DT0H0M0S'
+        pandas_input = {'param': [{'datetime': datetime_str, 'days': timedelta_str}]}
         datetime = pd.DataFrame(
             pd.DataFrame({'datetime': pd.Series([datetime_str], dtype='datetime64[ns]')})['datetime'])
         result = decorated_pandas_datetime_func(**pandas_input)

--- a/tests/test_schema_generation.py
+++ b/tests/test_schema_generation.py
@@ -33,6 +33,14 @@ class TestPandasSchemaGeneration(object):
         assert ordered(get_output_schema(decorated_pandas_func)) == ordered(self.pandas_sample_output_schema)
 
 
+class TestPandasDatetimeSchemaGeneration(object):
+    pandas_sample_datetime_schema = json.loads(
+        resource_string(__name__, os.path.join('resources', 'sample_pandas_datetime_schema.json')).decode('ascii'))
+
+    def test_pandas_datetime_handling(self, decorated_pandas_datetime_func):
+        assert ordered(get_input_schema(decorated_pandas_datetime_func)) == ordered(self.pandas_sample_datetime_schema)
+
+
 class TestSparkSchemaGeneration(object):
     spark_sample_input_schema = json.loads(
         resource_string(__name__, os.path.join('resources', 'sample_spark_input_schema.json')).decode('ascii'))


### PR DESCRIPTION
With the shift to using the builtin Pandas to_json, it converts datetime objects to integers instead of strings. This corrects that, and adds in the proper "format": "date-time" piece to the generated swagger, in order to better match the expectations of swagger itself.