### PR TITLE
Remove tests against python 3.5

### DIFF
--- a/.github/workflows/integration_build_test.yml
+++ b/.github/workflows/integration_build_test.yml
@@ -21,7 +21,7 @@ jobs:
       max-parallel: 3
       fail-fast: false
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
Removing Tests against py3.5 in prep to remove support for py3.5