### PR TITLE
Change apply_column_names default to false

### DIFF
--- a/inference_schema/parameter_types/pandas_parameter_type.py
+++ b/inference_schema/parameter_types/pandas_parameter_type.py
@@ -31,7 +31,7 @@ class PandasParameterType(AbstractParameterType):
         :type enforce_shape: bool
         :param apply_column_names: Apply column names from the provided sample onto the input when `deserialize_input`
             is called. Disabled by default, as there is no guaranteed order for dictionary keys, so it's possible for
-            names to be applied in the wrong order. Recommended to only use if the expected input will be an array 
+            names to be applied in the wrong order. Recommended to only use if the expected input will be an array
             representation of the dataframe.
         :type apply_column_names: bool
         :param orient: The Pandas orient to use when converting between a json object and a DataFrame. Possible orients

--- a/inference_schema/parameter_types/pandas_parameter_type.py
+++ b/inference_schema/parameter_types/pandas_parameter_type.py
@@ -45,7 +45,7 @@ class PandasParameterType(AbstractParameterType):
         super(PandasParameterType, self).__init__(sample_input)
         self.enforce_column_type = enforce_column_type
         self.enforce_shape = enforce_shape
-        
+
         if apply_column_names:
             warn('apply_column_names is a deprecated parameter and will be removed in a future update',
                  DeprecationWarning, stacklevel=2)

--- a/inference_schema/parameter_types/pandas_parameter_type.py
+++ b/inference_schema/parameter_types/pandas_parameter_type.py
@@ -14,7 +14,7 @@ class PandasParameterType(AbstractParameterType):
     Class used to specify an expected parameter as a Pandas type.
     """
 
-    def __init__(self, sample_input, enforce_column_type=True, enforce_shape=True, apply_column_names=True,
+    def __init__(self, sample_input, enforce_column_type=True, enforce_shape=True, apply_column_names=False,
                  orient='records'):
         """
         Construct the PandasParameterType object.
@@ -29,7 +29,9 @@ class PandasParameterType(AbstractParameterType):
             is called.
         :type enforce_shape: bool
         :param apply_column_names: Apply column names from the provided sample onto the input when `deserialize_input`
-            is called.
+            is called. Disabled by default, as there is no guaranteed order for dictionary keys, so it's possible for
+            names to be applied in the wrong order. Recommended to only use if the expected input will be an array 
+            representation of the dataframe.
         :type apply_column_names: bool
         :param orient: The Pandas orient to use when converting between a json object and a DataFrame. Possible orients
             are 'split', 'records', 'index', 'columns', 'values', or 'table'. More information about these orients can

--- a/inference_schema/parameter_types/pandas_parameter_type.py
+++ b/inference_schema/parameter_types/pandas_parameter_type.py
@@ -18,7 +18,12 @@ class PandasParameterType(AbstractParameterType):
     def __init__(self, sample_input, enforce_column_type=True, enforce_shape=True, apply_column_names=False,
                  orient='records'):
         """
-        Construct the PandasParameterType object.
+        Construct the PandasParameterType object. An important note regarding Pandas DataFrame handling; by default,
+        Pandas supports integer type column names in a DataFrame. However, when using the built in methods for
+        converting a json object to a DataFrame, unless all of the columns are integers, they will all be converted
+        to strings. This ParameterType uses the built in methods for performing conversion, and as such
+        `deserialize_input` has the same limitation. It is recommended to not use a mix of string and integer
+        type column names in the provided sample, as this can lead to inconsistent/unexpected behavior.
 
         :param sample_input: A sample input dataframe. This sample will be used as a basis for column types and array
             shape.
@@ -29,10 +34,10 @@ class PandasParameterType(AbstractParameterType):
         :param enforce_shape: Enforce that input shape must match that of the provided sample when `deserialize_input`
             is called.
         :type enforce_shape: bool
-        :param apply_column_names: Apply column names from the provided sample onto the input when `deserialize_input`
-            is called. Disabled by default, as there is no guaranteed order for dictionary keys, so it's possible for
-            names to be applied in the wrong order. Recommended to only use if the expected input will be an array
-            representation of the dataframe.
+        :param apply_column_names: [DEPRECATED] Apply column names from the provided sample onto the input when
+            `deserialize_input` is called. Disabled by default, as there is no guaranteed order for dictionary keys,
+            so it's possible for names to be applied in the wrong order when `deserialize_input` is called. The
+            property is deprecated, and will be removed in a future update.
         :type apply_column_names: bool
         :param orient: The Pandas orient to use when converting between a json object and a DataFrame. Possible orients
             are 'split', 'records', 'index', 'columns', 'values', or 'table'. More information about these orients can

--- a/inference_schema/parameter_types/pandas_parameter_type.py
+++ b/inference_schema/parameter_types/pandas_parameter_type.py
@@ -7,6 +7,7 @@ import pandas as pd
 from .abstract_parameter_type import AbstractParameterType
 from ._util import get_swagger_for_list, get_swagger_for_nested_dict
 from ._constants import SWAGGER_FORMAT_CONSTANTS
+from warnings import warn
 
 
 class PandasParameterType(AbstractParameterType):
@@ -44,6 +45,10 @@ class PandasParameterType(AbstractParameterType):
         super(PandasParameterType, self).__init__(sample_input)
         self.enforce_column_type = enforce_column_type
         self.enforce_shape = enforce_shape
+        
+        if apply_column_names:
+            warn('apply_column_names is a deprecated parameter and will be removed in a future update',
+                 DeprecationWarning, stacklevel=2)
         self.apply_column_names = apply_column_names
 
         if orient not in ('split', 'records', 'index', 'columns', 'values', 'table'):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,8 +58,8 @@ def pandas_sample_output():
 
 
 @pytest.fixture(scope="session")
-def pandas_sample_input_multi_type_column_labels():
-    pandas_input_data = {'name': ['Sarah', 'John'], 1: ['WA', 'CA']}
+def pandas_sample_input_int_column_labels():
+    pandas_input_data = {0: ['Sarah', 'John'], 1: ['WA', 'CA']}
     return pd.DataFrame(data=pandas_input_data)
 
 
@@ -121,10 +121,10 @@ def decorated_pandas_func_split_orient(pandas_sample_input, pandas_sample_output
 
 
 @pytest.fixture(scope="session")
-def decorated_pandas_func_multi_type_column_labels(pandas_sample_input_multi_type_column_labels):
+def decorated_pandas_func_int_column_labels(pandas_sample_input_int_column_labels):
 
-    @input_schema('param', PandasParameterType(pandas_sample_input_multi_type_column_labels))
-    def pandas_split_orient_func(param):
+    @input_schema('param', PandasParameterType(pandas_sample_input_int_column_labels))
+    def pandas_func(param):
         """
 
         :param param:
@@ -132,11 +132,11 @@ def decorated_pandas_func_multi_type_column_labels(pandas_sample_input_multi_typ
         :return:
         :rtype: pd.DataFrame
         """
-        assert param["name"] is not None
+        assert param[0] is not None
         assert param[1] is not None
         return param
 
-    return pandas_split_orient_func
+    return pandas_func
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_pandas_parameter_type.py
+++ b/tests/test_pandas_parameter_type.py
@@ -40,11 +40,11 @@ class TestPandasParameterType(object):
         result = decorated_pandas_datetime_func(**pandas_input)
         assert_frame_equal(result, datetime)
 
-    def test_pandas_multi_type_columns_labels_handling(self, decorated_pandas_func_multi_type_column_labels):
-        pandas_input = {'name': ['Sarah', 'John'], 1: ['WA', 'CA']}
-        result = decorated_pandas_func_multi_type_column_labels(pandas_input)
-        expected_result = pd.DataFrame(pandas_input)
-        assert_frame_equal(result, expected_result)
+    def test_pandas_int_column_labels(self, decorated_pandas_func_int_column_labels,
+                                      pandas_sample_input_int_column_labels):
+        input = pandas_sample_input_int_column_labels.to_dict(orient='records')
+        result = decorated_pandas_func_int_column_labels(input)
+        assert_frame_equal(result, pandas_sample_input_int_column_labels)
 
 
 class TestNestedType(object):

--- a/tests/test_schema_generation.py
+++ b/tests/test_schema_generation.py
@@ -29,8 +29,12 @@ class TestPandasSchemaGeneration(object):
         resource_string(__name__, os.path.join('resources', 'sample_pandas_output_schema.json')).decode('ascii'))
 
     def test_pandas_handling(self, decorated_pandas_func):
-        assert ordered(get_input_schema(decorated_pandas_func)) == ordered(self.pandas_sample_input_schema)
-        assert ordered(get_output_schema(decorated_pandas_func)) == ordered(self.pandas_sample_output_schema)
+        input_schema = get_input_schema(decorated_pandas_func)
+        output_schema = get_output_schema(decorated_pandas_func)
+        print("pandas input schema: ", input_schema)
+        print("pandas output schema: ", output_schema)
+        assert ordered(input_schema) == ordered(self.pandas_sample_input_schema)
+        assert ordered(output_schema) == ordered(self.pandas_sample_output_schema)
 
 
 class TestPandasDatetimeSchemaGeneration(object):


### PR DESCRIPTION
With the change to handling for different pandas splits, applying column names can result in breaking incoming dataframes when provided with a dictionary representation, as the key order isn't guaranteed to be consistent. A 'values' orient is likely the only one which could benefit from the parameter.