### PR TITLE
Don't fail validation for a float when provided an int

### DIFF
--- a/inference_schema/parameter_types/standard_py_parameter_type.py
+++ b/inference_schema/parameter_types/standard_py_parameter_type.py
@@ -57,6 +57,9 @@ class StandardPythonParameterType(AbstractParameterType):
             input_data = parser.parse(input_data).timetz()
         elif self.sample_data_type is bytearray or (sys.version_info[0] == 3 and self.sample_data_type is bytes):
             input_data = base64.b64decode(input_data.encode('utf-8'))
+        elif self.sample_data_type is float and type(input_data) is int:
+            # Allow users to pass ints when expecting floats, for convenience
+            pass
         if not isinstance(input_data, self.sample_data_type):
             raise ValueError("Invalid input data type to parse. Expected: {0} but got {1}".format(
                 self.sample_data_type, type(input_data)))


### PR DESCRIPTION
For user convenience, don't fail type validation if receiving an int when expecting a float. This avoids forcing users to pass "1.0" instead of just "1", for example