### PR TITLE
Ensure _get_function_full_qual_name() can get always get the module name

### DIFF
--- a/inference_schema/schema_util.py
+++ b/inference_schema/schema_util.py
@@ -3,7 +3,6 @@
 # ---------------------------------------------------------
 
 import copy
-import inspect
 
 from inference_schema._constants import INPUT_SCHEMA_ATTR, OUTPUT_SCHEMA_ATTR
 
@@ -110,7 +109,7 @@ def _get_function_full_qual_name(func):
 
     original_func = _get_decorators(func)[-1]
     base_func_name = original_func.__name__
-    module_name = getattr(original_func, "__module__", "<unknown>")
+    module_name = getattr(original_func, '__module__', '<unknown>')
     return '{}.{}'.format(module_name, base_func_name)
 
 

--- a/inference_schema/schema_util.py
+++ b/inference_schema/schema_util.py
@@ -108,10 +108,9 @@ def _get_function_full_qual_name(func):
     :rtype: str
     """
 
-    decorators = _get_decorators(func)
-    base_func_name = decorators[-1].__name__
-    module = inspect.getmodule(decorators[-1])
-    module_name = "" if module is None else module.__name__
+    original_func = _get_decorators(func)[-1]
+    base_func_name = original_func.__name__
+    module_name = getattr(original_func, "__module__", "<unknown>")
     return '{}.{}'.format(module_name, base_func_name)
 
 


### PR DESCRIPTION
`_get_function_full_qual_name()` cannot correctly detect the module name when if module is not available in `sys.modules` due to how `inspect.getmodule()` [is implemented](https://github.com/python/cpython/blob/3fc57e8f6ff925b561b03c46bcf5bd323782c19c/Lib/inspect.py#L976-L977). Since we only need the module name, updating the function to read from `__module__`.