### PR TITLE
Fix for non-IS decorators

### DIFF
--- a/inference_schema/schema_util.py
+++ b/inference_schema/schema_util.py
@@ -99,7 +99,7 @@ def _get_decorators(func):
     """
 
     dec = []
-    if not func.__closure__:
+    if not hasattr(func, '__closure__') or not func.__closure__:
         return [func]
     if hasattr(func, '__closure__'):
         for closure in func.__closure__:
@@ -118,7 +118,7 @@ def _get_function_full_qual_name(func):
     """
 
     original_func = _get_decorators(func)[-1]
-    base_func_name = original_func.__name__
+    base_func_name = getattr(original_func, '__name__', '<unknown>')
     module_name = getattr(original_func, '__module__', '<unknown>')
     return '{}.{}'.format(module_name, base_func_name)
 

--- a/tests/test_schema_util.py
+++ b/tests/test_schema_util.py
@@ -1,0 +1,43 @@
+# ---------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# ---------------------------------------------------------
+
+from inference_schema.parameter_types.standard_py_parameter_type import StandardPythonParameterType
+from inference_schema.schema_decorators import input_schema, output_schema
+from inference_schema.schema_util import is_schema_decorated
+
+
+@input_schema('data', StandardPythonParameterType('Hello'))
+def input_decorated_function(data):
+    return data
+
+
+@output_schema(StandardPythonParameterType('Hello'))
+def output_decorated_function(data):
+    return data
+
+
+@input_schema('data', StandardPythonParameterType('Hello'))
+@output_schema(StandardPythonParameterType('Hello'))
+def both_decorated_function(data):
+    return data
+
+
+def passthrough_decorator(wrapt_func):
+    def inner_func(*args, **kwargs):
+        return wrapt_func(*args, **kwargs)
+    return inner_func
+
+
+@passthrough_decorator
+def custom_decorator_function(data):
+    return data
+
+
+class TestSchemaUtil(object):
+
+    def test_is_schema_decorated(self):
+        assert is_schema_decorated(input_decorated_function)
+        assert is_schema_decorated(output_decorated_function)
+        assert is_schema_decorated(both_decorated_function)
+        assert not is_schema_decorated(custom_decorator_function)


### PR DESCRIPTION
Handling for functions which are decorated with other decorators which don't surface underlying functions